### PR TITLE
typo fixes, --rm verification container

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,7 +36,7 @@ apt-get install -y docker-ce'''
         }
         stage('\u27A1 Verify Docker') {
             steps {
-                sh 'docker run hello-world'
+                sh 'docker run --rm hello-world'
             }
         }
         stage('\u27A1 Verify ChefDK') {

--- a/README.md
+++ b/README.md
@@ -15,45 +15,37 @@ in example with only a couple tweaks to make it work in your environment.
 ## Explanation
 
 This file was verified against the [sudo][sudo] cookbook from the chef-cookbooks
-github repository. It's supported by the Awesome Chef Community Engineering team,
+GitHub repository. It's supported by the Awesome Chef Community Engineering team,
 and normally is verified via Travis. The Travis workflow works awesome in a public
 setting, but this Jenkinsfile is a way to bring that same workflow in house. I chose
 the Docker workflow to help create a quick disposable environment, so you have a "clean"
 test bed every time you run your Pipeline.
 
-This is only an framework, you will need to configure a few of the settings for your
+This is only a framework, you will need to configure a few of the settings for your
 specific use case, but this should be the lions share of the work you need.
-
-Here's an example of the Blue Ocean Pipeline:
-
-![](./images/blueocean.png)
-
-And the "default" Pipeline plugin for Jenkins:
-
-![](./images/pipeline.png)
 
 ## Jenkinsfile
 
 I'll walk through each section explain what each does, to make sure we are on the same
 page. I consider a section `{..}`, and I'll name it via the line number too. Lets go!
 
-- Line 1 `node {` - This is the setup for the node and workspace that runs the Job. As you can see we use the `git` command in `stage`. A `stage` is the declaritive unit of a job in the Jenkinsfile, as you can see the first `stage` I name it 'Checkout code' which will checkout the `master` branch from the `git` repo I declare at `REPO`.
+- Line 1 `node {` - This is the setup for the node and workspace that runs the Job. As you can see we use the `git` command in `stage`. A `stage` is the declarative unit of a job in the Jenkinsfile, as you can see the first `stage` I name it 'Checkout code' which will checkout the `master` branch from the `git` repo I declare at `REPO`.
 - Line 6 `pipeline {` - This is the main declaration of the specific pipeline, everything goes in here.
-- Line 7 `agent {` - This sets up the agent that does the work in the workspace. As you can see this command uses the standard `chef/chefdk` container with the [chefdk][chefdk] already in it. The `-u root` allows us to install some dependacies into the container, and because we use `kitchen-dokken` later on, we have "Docker in Docker" which is the bind mount of `/var/run/docker.sock`.
-- Line 14 `triggers {` - This line is how often the pipeline should be ran. I put an `H` in for the min, which is a "random number". It also `pollSCM` to see if the git sha has changed, and only pulls down if it has. This helps with network overhead with larger repositories.
+- Line 7 `agent {` - This sets up the agent that does the work in the workspace. As you can see this command uses the standard `chef/chefdk` container with the [chefdk][chefdk] already in it. The `-u root` allows us to install some dependencies into the container, and because we use `kitchen-dokken` later on, we have "Docker in Docker" which is the bind mount of `/var/run/docker.sock`.
+- Line 14 `triggers {` - This line is how often the pipeline should run. I put an `H` in for the min, which is a "random number". It also uses `pollSCM` to see if the git sha has changed, and only pulls down if it has. This helps with network overhead with larger repositories.
 - Line 17 `stages {` - The location for all the "build stages" to be declared.
 - Line 18 `stage('\u27A1 Dependencies for Docker and ChefDK') {` - The first place where real work is done. This stage updates the `apt` repositories, installs things required for Docker to be able to be built.
-- Line 24 `stage('\u27A1 Install Docker-CE') {` - This installs Docker-CE, it's the standard installation, with so you can run `kitchen-dokken`.
-- Line 32 `stage('\u27A1 Start Docker') {` - In my testing, installing Docker in Docker, the service _somtimes_ doesn't start. This stage sends a start command to the service to make sure it is up and running.
+- Line 24 `stage('\u27A1 Install Docker-CE') {` - This installs standard Docker-CE, with it you can run `kitchen-dokken`.
+- Line 32 `stage('\u27A1 Start Docker') {` - In my testing while installing Docker in Docker, the service _sometimes_ didn't start. This stage sends a start command to the service to make sure it is up and running.
 - Line 37 `stage('\u27A1 Verify Docker') {` - Verifying Docker is a safe sanity check in this pipeline. Running the `docker run hello-world` shows you can call out to the Public Repos, run the docker command, and have an output.
 - Line 42 `stage('\u27A1 Verify ChefDK') {` - This verifies that the ChefDK commands run as expected. Also it helps with debugging version numbers if something goes off the rails.
 - Line 49 `stage('\u27A1 Verify Kitchen') {` - Because we are focusing on using `kitchen-dokken` as our driver, this outputs all the versions of the suites and platforms. It also verifies that `test-kitchen` is properly set up and can take commands.
-- Line 53 `stage('\u27A1 Run test-kitchen') {` - The true meat of this file. We run in _parallel_ (Line 55) 5 versions of `kitchen-dokken` focusing on the platforms. This allows for concurancy and the ability to verify quicker. Also using `test` as the commaand, it cleans up the previous containers, and run the Inspec validation after each of the converges allowing for better visibility.
+- Line 53 `stage('\u27A1 Run test-kitchen') {` - The true meat of this file. We run `kitchen-dokken` for each of the five platforms in _parallel_ (Line 55). This allows for concurrency and faster verification. Also using `test` as the command, it cleans up the previous containers, and run the Inspec validation after each of the converges allowing for better visibility.
 - Line 74 `stage('\u27A1 Upload to Chef Server') {` - And as a final stage, we can upload the cookbook to our Chef server. Now, if you've read this far, you'll probably be wondering how to do this, we haven't done any configuration to this. That's our next section.
 
 ## Publishing or "shipping code"
 
-Now that you've configured your Jenkinfile with the generic `chef/chefdk` you'll
+Now that you've configured your Jenkinsfile with the generic `chef/chefdk` you'll
 probably want to publish to your Chef server if everything has passed. This next
 section is a tad bit more complex, but pretty straight forward.
 
@@ -73,7 +65,7 @@ CONTAINER ID        IMAGE               COMMAND             CREATED             
 $
 ```
 
-Back on the `chef/chefdk` docker container, create a `.chef` diretory at `$HOME` which is `/`:
+Back on the `chef/chefdk` docker container, create a `.chef` directory at `$HOME` which is `/`:
 
 ```bash
 root@7425261cb693:/# mkdir .chef
@@ -95,7 +87,7 @@ root@7425261cb693:/# chef exec knife status
 20 minutes ago, web01
 ```
 
-Awesome! Ok, so now we need to commit and save this container. Occationally, you'll need to go through these
+Awesome! OK, so now we need to commit and save this container. Occasionally, you'll need to go through these
 steps when a new `chef/chefdk` base container is released, back to the `versioning` step.
 
 Back on the workstation, we are going to set up a local registry, inject the container into it.
@@ -104,7 +96,7 @@ Back on the workstation, we are going to set up a local registry, inject the con
 $ docker run -d -p 5000:5000 --restart=always --name registry registry:2 # start up registry container if not already started
 $ docker commit -m "keys included for Chef Server" 7425261cb693 # commit the changes to the container
 $ docker images -a # list images to verify that it has been committed
-$ docker tag 7425261cb693 localhost:5000/chefdkkeysv1 # tag the image you commited
+$ docker tag 7425261cb693 localhost:5000/chefdkkeysv1 # tag the image you committed
 $ docker push localhost:5000/chefdkkeysv1 # push to local registry
 ```
 
@@ -129,7 +121,7 @@ chef server if everything passes.
 ## Conclusion
 
 Hopefully this will give you the framework you need to get your own Jenkinsfile configured for your own environment.
-There are a few configurtions you'll need to make in the process, namely the `keys` and `knife.rb` but assuming you
+There are a few configurations you'll need to make in the process, namely the `keys` and `knife.rb` but assuming you
 just want to verify you can drop the final example `stage`. If you have questions never hesitate to reach out via
 the Chef-Community Slack, `@jj`.
 


### PR DESCRIPTION
- quick comb with `aspell check README.md`
- add --rm flag to `docker run` when verifying with `hello-world` to prevent accumulation of stopped containers