### PR TITLE
Remove checkout and add branch conditionals

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,7 +48,7 @@ apt-get install -y docker-ce'''
         stage('\u27A1 Run test-kitchen') {
             
             when {
-                anyOf { branch 'master'; branch 'staging' }
+                anyOf { branch 'master'; branch 'staging'; branch 'production' }
             }
             
             steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,8 +1,3 @@
-node {
-    stage('Checkout code') {
-        git 'REPO'
-    }
-}
 pipeline {
     agent {
         docker {
@@ -51,6 +46,11 @@ apt-get install -y docker-ce'''
             }
         }
         stage('\u27A1 Run test-kitchen') {
+            
+            when {
+                anyOf { branch 'master'; branch 'staging' }
+            }
+            
             steps {
                 parallel(
                     "centos": {
@@ -72,7 +72,13 @@ apt-get install -y docker-ce'''
             }
         }
         stage('\u27A1 Upload to Chef Server') {
-            steps { sh 'chef exec knife cookbook upload COOKBOOKNAME -o ../'
+            
+            when {
+                branch 'production'
+            }
+            
+            steps { 
+                sh 'chef exec knife cookbook upload COOKBOOKNAME -o ../'
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ the Docker workflow to help create a quick disposable environment, so you have a
 test bed every time you run your Pipeline.
 
 This is only a framework, you will need to configure a few of the settings for your
-specific use case, but this should be the lions share of the work you need.
+specific use case, but this should be the lions share of the work you need. 
+This Jenkinsfile is intended to be used as a "multi branch pipeline" job type in Jenkins, 
+and live alongside your code. 
 
 Here's an example of the Blue Ocean Pipeline:
 
@@ -37,18 +39,17 @@ And the "default" Pipeline plugin for Jenkins:
 I'll walk through each section explain what each does, to make sure we are on the same
 page. I consider a section `{..}`, and I'll name it via the line number too. Lets go!
 
-- Line 1 `node {` - This is the setup for the node and workspace that runs the Job. As you can see we use the `git` command in `stage`. A `stage` is the declarative unit of a job in the Jenkinsfile, as you can see the first `stage` I name it 'Checkout code' which will checkout the `master` branch from the `git` repo I declare at `REPO`.
-- Line 6 `pipeline {` - This is the main declaration of the specific pipeline, everything goes in here.
-- Line 7 `agent {` - This sets up the agent that does the work in the workspace. As you can see this command uses the standard `chef/chefdk` container with the [chefdk][chefdk] already in it. The `-u root` allows us to install some dependencies into the container, and because we use `kitchen-dokken` later on, we have "Docker in Docker" which is the bind mount of `/var/run/docker.sock`.
-- Line 14 `triggers {` - This line is how often the pipeline should run. I put an `H` in for the min, which is a "random number". It also uses `pollSCM` to see if the git sha has changed, and only pulls down if it has. This helps with network overhead with larger repositories.
-- Line 17 `stages {` - The location for all the "build stages" to be declared.
-- Line 18 `stage('\u27A1 Dependencies for Docker and ChefDK') {` - The first place where real work is done. This stage updates the `apt` repositories, installs things required for Docker to be able to be built.
-- Line 24 `stage('\u27A1 Install Docker-CE') {` - This installs standard Docker-CE, with it you can run `kitchen-dokken`.
-- Line 32 `stage('\u27A1 Start Docker') {` - In my testing while installing Docker in Docker, the service _sometimes_ didn't start. This stage sends a start command to the service to make sure it is up and running.
-- Line 37 `stage('\u27A1 Verify Docker') {` - Verifying Docker is a safe sanity check in this pipeline. Running the `docker run hello-world` shows you can call out to the Public Repos, run the docker command, and have an output.
-- Line 42 `stage('\u27A1 Verify ChefDK') {` - This verifies that the ChefDK commands run as expected. Also it helps with debugging version numbers if something goes off the rails.
-- Line 49 `stage('\u27A1 Verify Kitchen') {` - Because we are focusing on using `kitchen-dokken` as our driver, this outputs all the versions of the suites and platforms. It also verifies that `test-kitchen` is properly set up and can take commands.
-- Line 53 `stage('\u27A1 Run test-kitchen') {` - The true meat of this file. We run `kitchen-dokken` for each of the five platforms in _parallel_ (Line 55). This allows for concurrency and faster verification. Also using `test` as the command, it cleans up the previous containers, and run the Inspec validation after each of the converges allowing for better visibility.
+- Line 1 `pipeline {` - This is the main declaration of the specific pipeline, everything goes in here.
+- Line 2 `agent {` - This sets up the agent that does the work in the workspace. As you can see this command uses the standard `chef/chefdk` container with the [chefdk][chefdk] already in it. The `-u root` allows us to install some dependencies into the container, and because we use `kitchen-dokken` later on, we have "Docker in Docker" which is the bind mount of `/var/run/docker.sock`.
+- Line 9 `triggers {` - This line is how often the pipeline should run. I put an `H` in for the min, which is a "random number". It also uses `pollSCM` to see if the git sha has changed, and only pulls down if it has. This helps with network overhead with larger repositories.
+- Line 12 `stages {` - The location for all the "build stages" to be declared.
+- Line 13 `stage('\u27A1 Dependencies for Docker and ChefDK') {` - The first place where real work is done. This stage updates the `apt` repositories, installs things required for Docker to be able to be built.
+- Line 19 `stage('\u27A1 Install Docker-CE') {` - This installs standard Docker-CE, with it you can run `kitchen-dokken`.
+- Line 27 `stage('\u27A1 Start Docker') {` - In my testing while installing Docker in Docker, the service _sometimes_ didn't start. This stage sends a start command to the service to make sure it is up and running.
+- Line 32 `stage('\u27A1 Verify Docker') {` - Verifying Docker is a safe sanity check in this pipeline. Running the `docker run hello-world` shows you can call out to the Public Repos, run the docker command, and have an output.
+- Line 37 `stage('\u27A1 Verify ChefDK') {` - This verifies that the ChefDK commands run as expected. Also it helps with debugging version numbers if something goes off the rails.
+- Line 44 `stage('\u27A1 Verify Kitchen') {` - Because we are focusing on using `kitchen-dokken` as our driver, this outputs all the versions of the suites and platforms. It also verifies that `test-kitchen` is properly set up and can take commands.
+- Line 48 `stage('\u27A1 Run test-kitchen') {` - The true meat of this file. We run `kitchen-dokken` for each of the five platforms in _parallel_ (Line 55). This allows for concurrency and faster verification. Also using `test` as the command, it cleans up the previous containers, and run the Inspec validation after each of the converges allowing for better visibility.
 - Line 74 `stage('\u27A1 Upload to Chef Server') {` - And as a final stage, we can upload the cookbook to our Chef server. Now, if you've read this far, you'll probably be wondering how to do this, we haven't done any configuration to this. That's our next section.
 
 ## Publishing or "shipping code"
@@ -124,7 +125,7 @@ docker {
 ```
 
 With this, your final stage of `stage('\u27A1 Upload to Chef Server') {` should start publishing to your
-chef server if everything passes.
+chef server if everything passes. Note this only happens on the production branch (see the `when` statement).
 
 ## Input or Approval Gate
 
@@ -142,6 +143,19 @@ stage('\u27A1 Upload to Chef Server') {
 Here's an image of what it looks like on Blue Ocean!
 
 ![](./images/paused_blueocean.png)
+
+## Conditionally running stages only on specified branches
+
+On line 51: 
+
+```
+when {
+    anyOf { branch 'master'; branch 'staging' }
+}
+```
+specifies that the 'Run test-kitchen' stage should run only on the master, staging or production branches. No need to do this work on other experimental branches. 
+Likewise, on the upload stage, it will be skipped unless the production branch is updated. You can specify a single branch or multiple branches to run on.
+
 
 
 ## Conclusion


### PR DESCRIPTION
If people use a multibranch pipeline - they can keep the Jenkinsfile inside the repo alongside their code - and use conditionals to only run parts of the pipeline on branches. Eg only test on master or prod, only upload the cookbook on prod. 

https://jenkins.io/doc/book/pipeline/syntax/#when
https://jenkins.io/doc/book/pipeline/multibranch/